### PR TITLE
Виправлення помилки при імпорті модулів запуску

### DIFF
--- a/src/startup-modules/index.js
+++ b/src/startup-modules/index.js
@@ -1,8 +1,7 @@
 import fs from "fs";
 import path from "path";
-import getStartupModuleDirectory from "./config.js";
+import startupModuleDir from "./config.js";
 
-const startupModuleDir = getStartupModuleDirectory();
 const startupModuleFiles = fs.readdirSync(startupModuleDir);
 
 const startupModules = [];


### PR DESCRIPTION
Причиною була спроба імпортувати змінну зі шляхом до папки модулів запуску і використати її як функцію `getStartupModuleDirectory()`.