### PR TITLE
Коректна термінологія в назвах функцій математичного модуля

### DIFF
--- a/src/library/mathModule.js
+++ b/src/library/mathModule.js
@@ -24,7 +24,7 @@ const makeMathModule = (mavka) => {
     "арктан2": mavka.makeProxyFunction((args, context, { arg }) => mavka.makeNumber(
       Math.atan2(arg(0, "х").asJsValue(context), arg(0, "y").asJsValue(context)))
     ),
-    "небо": mavka.makeProxyFunction((args, context, { arg }) => mavka.makeNumber(
+    "стеля": mavka.makeProxyFunction((args, context, { arg }) => mavka.makeNumber(
       Math.ceil(arg(0, "значення").asJsValue(context)))
     ),
     "кос": mavka.makeProxyFunction((args, context, { arg }) => mavka.makeNumber(
@@ -33,7 +33,7 @@ const makeMathModule = (mavka) => {
     "експ": mavka.makeProxyFunction((args, context, { arg }) => mavka.makeNumber(
       Math.exp(arg(0, "значення").asJsValue(context)))
     ),
-    "земля": mavka.makeProxyFunction((args, context, { arg }) => mavka.makeNumber(
+    "підлога": mavka.makeProxyFunction((args, context, { arg }) => mavka.makeNumber(
       Math.floor(arg(0, "значення").asJsValue(context)))
     ),
     "найбільше": mavka.makeProxyFunction((args, context) => mavka.makeNumber(


### PR DESCRIPTION
Коректними назвами до функцій `floor()` і `ceiling()` є `підлога()` і `стеля()` відповідно (https://uk.wikipedia.org/wiki/Ціла_частина_числа).
Неправильна назва функцій буде заважати людям знайомим з основними математичними функціями і іншими мовами програмування, ускладнить пошук значення даних функцій в інтернеті (їх значення буде доступно тільки в документації, пошук в інтернеті не дасть результатів).