### PR TITLE
Оновити CHANGELOG.md, версія 0.10.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Список змін Мавки
 
+## [0.10.47]
+
+- виправлення https://github.com/mavka-ukr/mavka/pull/49
+
 ## [0.10.46]
 
 - додано вбудований модуль `фс`: https://github.com/mavka-ukr/mavka/pull/44


### PR DESCRIPTION
Додати інформацію про версію 0.10.47 у CHANGELOG. Нехай буде хоч одне місце із повним списоком змін, якими б маленькими вонм не були...